### PR TITLE
fix: bundle service sealed issue

### DIFF
--- a/syncer/verifier.go
+++ b/syncer/verifier.go
@@ -92,7 +92,8 @@ func (b *BlockIndexer) verify() error {
 				}
 				// check the object info from chain to make sure it is not be sealed
 				// if it is not be sealed, re-upload it
-				if objectMeta.ObjectStatus == "OBJECT_STATUS_SEALED" {
+				// "is expected to be OBJECT_STATUS_CREATED status but actually OBJECT_STATUS_SEALED status" bundle service upload issue, we need to re-upload it
+				if objectMeta.ObjectStatus == "OBJECT_STATUS_SEALED" && !strings.Contains(bundleInfo.ErrorMessage, "is expected to be OBJECT_STATUS_CREATED status but actually OBJECT_STATUS_SEALED status") {
 					return nil
 				}
 				return b.reUploadBundle(bundleName)


### PR DESCRIPTION
### Description

```
&{mainnet-bsc-blocks blocks_s8306920_e8306939 1724305211 submit bundle failed: statusCode 400 : code : 20003  (Message: object blocks_s8306920_e8306939 is expected to be OBJECT_STATUS_CREATED status but actually OBJECT_STATUS_SEALED status) 20 2592124 1}
```
resolved the issue where verification was continuously hanging due to an unsuccessful update caused by the bundle service being sealed.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* resolved the issue where verification was continuously hanging due to an unsuccessful update caused by the bundle service being sealed.